### PR TITLE
Add a renderOption prop on SegmentedControls

### DIFF
--- a/lib/segmented-controls.js
+++ b/lib/segmented-controls.js
@@ -88,7 +88,9 @@ class SegmentedControls extends React.Component {
     return (
       <TouchableWithoutFeedback onPress={onSelect} key={index}>
         <View style={index > 0 ? separatorStyle : baseOptionContainerStyle}>
-          <Text style={style}>{label}</Text>
+          {'function' === typeof this.props.renderOption ? this.props.renderOption.bind(this)(option, selected) : (
+            <Text style={style}>{label}</Text>
+          )}
         </View>
       </TouchableWithoutFeedback>
     );


### PR DESCRIPTION
I wanted to add icons to my SegmentedControls buttons. I am not sure if there is a reason why only Text buttons are allowed but this pull requests introduces a `renderOption` prop which will allow an implementation to do something like:

``` jsx
  <SegmentedControls
    options         = {modes}
    onSelection     = {this.setMode.bind(this)}
    selectedOption  = {this.state.mode}
    renderOption    = {(option, selected) => {
      return (
        // ...render stuff
      )
    }}
  />
```

I made it so that if `renderOption` is not present, the default implementation is used:

``` javascript
  {'function' === typeof this.props.renderOption ? this.props.renderOption.bind(this)(option, selected) : (
    <Text style={style}>{label}</Text>
  )}
```
