### PR TITLE
pass prop for fontscaling

### DIFF
--- a/lib/segmented-controls.js
+++ b/lib/segmented-controls.js
@@ -85,11 +85,15 @@ class SegmentedControls extends React.Component {
 
     const label = this.props.extractText ? this.props.extractText(option) : option;
 
+    // Default to true for undefined - like RN currently does
+    const scaleFont = (this.props.allowFontScaling === false) ? false : true
+
+
     return (
       <TouchableWithoutFeedback onPress={onSelect} key={index}>
         <View style={index > 0 ? separatorStyle : baseOptionContainerStyle}>
           {'function' === typeof this.props.renderOption ? this.props.renderOption.call(this, option, selected) : (
-            <Text style={style}>{label}</Text>
+            <Text allowFontScaling={scaleFont} style={style}>{label}</Text>
           )}
         </View>
       </TouchableWithoutFeedback>


### PR DESCRIPTION
Default for font scaling is true on text.  [As of right now](https://github.com/facebook/react-native/issues/2519) you have to go modify each text item to disable it.   I've added the ability to pass along `allowFontScaling` to default segmented controls.
## before

![screen shot 2015-12-23 at 12 42 49 pm](https://cloud.githubusercontent.com/assets/997157/11982941/2fcb3a60-a975-11e5-9ccd-323905102537.png)
## after

![image](https://cloud.githubusercontent.com/assets/997157/11982936/245a990a-a975-11e5-81f6-491b180ab218.png)
