### PR TITLE
Selected index

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,10 @@ Will render this
 ## Props
 
 * `options - []` mandatory array of anything, will be passed to `renderOption`
-* `onSelection - function(option){}` option selection callback
+* `onSelection - function(selectedOption, selectedIndex){}` option selection callback
+* `selectedIndex - index` the  initially selected index, optional.
 * `selectedOption - option` the initially selected option, optional
-* `renderOption - function(option, selected, onSelect, index)` should return an option node, default generate `<Text>` nodes and adds `{fontWieght:'bold'}` to the selected option.
+* `renderOption - function(option, selected, onSelect, index)` should return an option node, default generate `<Text>` nodes and adds `{fontWeight:'bold'}` to the selected option.
 * `renderContainer - function(optionsNodes)` must render the container, default is RadioButtons.renderVerticalContainer (see below)
 
 ### Full javascript SegmentedControls clone

--- a/lib/radio-buttons.js
+++ b/lib/radio-buttons.js
@@ -24,9 +24,10 @@ class RadioButtons extends React.Component {
     };
   }
 
-  copySelectedOptionFromProps({selectedOption}){
+  copySelectedOptionFromProps({selectedOption, selectedIndex}){
     this.setState({
       selectedOption,
+      selectedIndex,
     });
   }
 
@@ -47,10 +48,10 @@ class RadioButtons extends React.Component {
   }
 
   render() {
-    const {selectedOption} = this.state;
+    const {selectedOption, selectedIndex} = this.state;
 
     const children = this.props.options.map(function(option, index){
-      const isSelected = this.props.testOptionEqual(selectedOption, option);
+      const isSelected = selectedIndex === index || this.props.testOptionEqual(selectedOption, option);
       const onSelection = this.selectOption.bind(this, option, index);
 
       return this.props.renderOption(option, isSelected, onSelection, index);

--- a/lib/radio-buttons.js
+++ b/lib/radio-buttons.js
@@ -19,7 +19,8 @@ class RadioButtons extends React.Component {
   constructor(){
     super();
     this.state = {
-      selectedOption: null
+      selectedOption: null,
+      selectedIndex: null,
     };
   }
 
@@ -37,11 +38,12 @@ class RadioButtons extends React.Component {
     this.copySelectedOptionFromProps(newProps);
   }
 
-  selectOption(selectedOption){
+  selectOption(selectedOption, selectedIndex){
     this.setState({
-      selectedOption
+      selectedOption,
+      selectedIndex,
     });
-    this.props.onSelection(selectedOption);
+    this.props.onSelection(selectedOption, selectedIndex);
   }
 
   render() {
@@ -49,7 +51,7 @@ class RadioButtons extends React.Component {
 
     const children = this.props.options.map(function(option, index){
       const isSelected = this.props.testOptionEqual(selectedOption, option);
-      const onSelection = this.selectOption.bind(this, option);
+      const onSelection = this.selectOption.bind(this, option, index);
 
       return this.props.renderOption(option, isSelected, onSelection, index);
     }.bind(this));


### PR DESCRIPTION
I was faced to a use case that I need the index of selected option instead of his value.

So I added `selectedIndex` to `onSelection` and as initial selected value. You can now defined initial selected value by the following props : `selectedOption` or `selectedIndex`.

``` diff
+setSelectedOption(selectedOption, selectedIndex) {
  console.log('selectedOption', selectedOption);
+ console.log('selectedIndex', selectedIndex);
}

...

<SegmentedControls
  options={ options }
  onSelection={ setSelectedOption.bind(this) }
- selectedOption={ this.state.selectedOption }
+ selectedIndex={ this.state.selectedIndex }
/>
```

Tested with SegmentedControl only on Android.
