### PR TITLE
ReacNative.Component deprecated

### DIFF
--- a/lib/radio-buttons.js
+++ b/lib/radio-buttons.js
@@ -1,11 +1,11 @@
 'use strict';
-var React = require('react-native');
+import React, { Component } from 'react';
 
-const {
+import {
   Text,
   TouchableWithoutFeedback,
-  View,
-} = React;
+  View
+} from 'react-native';
 
 const propTypes = {
   options: React.PropTypes.array.isRequired,
@@ -15,7 +15,7 @@ const propTypes = {
   onSelection: React.PropTypes.func,
 };
 
-class RadioButtons extends React.Component {
+class RadioButtons extends Component {
   constructor(){
     super();
     this.state = {
@@ -96,4 +96,4 @@ RadioButtons.defaultProps = {
 };
 RadioButtons.propTypes = propTypes;
 
-module.exports = RadioButtons;
+export default RadioButtons;

--- a/lib/segmented-controls.js
+++ b/lib/segmented-controls.js
@@ -1,15 +1,15 @@
 'use strict';
-import React from 'react-native';
+import React, { Component } from 'react';
 import RadioButtons from './';
 
-const {
+import {
   Text,
   TouchableWithoutFeedback,
   View,
   Platform
-} = React;
+} from 'react-native' ;
 
-class SegmentedControls extends React.Component {
+class SegmentedControls extends Component {
 
   render(){
     const config = this.getConfig();


### PR DESCRIPTION
As of 25.1 Component must be imported from React.

https://github.com/facebook/react-native/releases/tag/v0.25.1
