### PR TITLE
Splits react-native and react to avoid warnings on >= 0.25

### DIFF
--- a/lib/radio-buttons.js
+++ b/lib/radio-buttons.js
@@ -1,11 +1,12 @@
 'use strict';
-var React = require('react-native');
+var React = require('react');
+var ReactNative = require('react-native');
 
 const {
   Text,
   TouchableWithoutFeedback,
   View,
-} = React;
+} = ReactNative;
 
 const propTypes = {
   options: React.PropTypes.array.isRequired,

--- a/lib/segmented-controls.js
+++ b/lib/segmented-controls.js
@@ -1,5 +1,6 @@
 'use strict';
-import React from 'react-native';
+import React from 'react';
+import ReactNative from 'react-native';
 import RadioButtons from './';
 
 const {
@@ -7,7 +8,7 @@ const {
   TouchableWithoutFeedback,
   View,
   Platform
-} = React;
+} = ReactNative;
 
 class SegmentedControls extends React.Component {
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "git@github.com:ArnaudRinquin/react-native-radio-buttons.git"
   },
   "peerDependencies": {
-    "react-native": ">=0.8.0"
+    "react-native": ">=0.25.0"
   },
   "keywords": [
     "react-component",


### PR DESCRIPTION
[Starting from 0.25, creating components from 'react-native' is a deprecated](https://github.com/facebook/react-native/releases/tag/v0.25.1).

This pull request avoids warnings on this version.
