### PR TITLE
Fixes strange style behavior in Android 0.31.0

### DIFF
--- a/lib/segmented-controls.js
+++ b/lib/segmented-controls.js
@@ -74,6 +74,7 @@ class SegmentedControls extends React.Component {
     const baseColor = selected? config.selectedBackgroundColor: config.backgroundColor;
 
     const baseOptionContainerStyle = {
+      flex: 1,
       paddingTop: config.paddingTop,
       paddingBottom: config.paddingBottom,
       backgroundColor: baseColor,


### PR DESCRIPTION
My problem in #36 is fixed by this addition:
### BEFORE:

![before](https://cloud.githubusercontent.com/assets/997157/17643819/c7e015dc-613a-11e6-9aa5-4728be2c5763.png)
### AFTER:

![screen shot 2016-08-13 at 3 11 13 pm](https://cloud.githubusercontent.com/assets/997157/17645325/44b6c006-6168-11e6-81ed-bae398294ed9.png)
