### PR TITLE
Add support to disable SegmentedControl

### DIFF
--- a/lib/segmented-controls.js
+++ b/lib/segmented-controls.js
@@ -62,6 +62,8 @@ class SegmentedControls extends React.Component {
 
   renderOption(config, option, selected, onSelect, index){
 
+    const disabled = !this.props.enabled || false;
+
     const baseStyle = {
       textAlign: config.textAlign,
     };
@@ -73,10 +75,12 @@ class SegmentedControls extends React.Component {
 
     const baseColor = selected? config.selectedBackgroundColor: config.backgroundColor;
 
+    const opacity = disabled ? 0.5 : 1.0;
     const baseOptionContainerStyle = {
       paddingTop: config.paddingTop,
       paddingBottom: config.paddingBottom,
       backgroundColor: baseColor,
+      opacity: opacity
     };
 
     const normalStyle = [baseStyle, this.props.optionStyle, {
@@ -103,7 +107,7 @@ class SegmentedControls extends React.Component {
     const scaleFont = (this.props.allowFontScaling === false) ? false : true;
 
     return (
-      <TouchableWithoutFeedback onPress={onSelect} key={index}>
+      <TouchableWithoutFeedback onPress={onSelect} key={index} disabled={disabled}>
         <View style={[index > 0 ? separatorStyle : baseOptionContainerStyle, this.props.optionContainerStyle]}>
           {typeof this.props.renderOption === 'function' ? this.props.renderOption.call(this, option, selected) : (
             <Text allowFontScaling={scaleFont} style={style}>{label}</Text>


### PR DESCRIPTION
Added prop `enabled` similar to `SegmentedControlIOS` which can be used to enable/disable the segmented control options. Default is enabled.
