### PR TITLE
Fix styling of disabled segmented control

### DIFF
--- a/lib/segmented-controls.js
+++ b/lib/segmented-controls.js
@@ -64,17 +64,19 @@ class SegmentedControls extends React.Component {
 
     const disabled = !this.props.enabled || false;
 
-    const baseStyle = {
-      textAlign: config.textAlign,
+    const baseTextStyle = {
+      textAlign: config.textAlign
     };
 
-    const selectedStyle = [baseStyle, this.props.optionStyle, {
-      color: config.selectedTint,
-      backgroundColor: config.selectedBackgroundColor,
+    const normalTextStyle = [baseTextStyle, this.props.optionStyle, {
+      color: config.tint
+    }];
+
+    const selectedTextStyle = [baseTextStyle, this.props.optionStyle, {
+      color: config.selectedTint
     }];
 
     const baseColor = selected? config.selectedBackgroundColor: config.backgroundColor;
-
     const opacity = disabled ? 0.5 : 1.0;
     const baseOptionContainerStyle = {
       flex: 1,
@@ -83,11 +85,6 @@ class SegmentedControls extends React.Component {
       backgroundColor: baseColor,
       opacity: opacity
     };
-
-    const normalStyle = [baseStyle, this.props.optionStyle, {
-      color: config.tint,
-      backgroundColor: config.backgroundColor
-    }];
 
     const borderStyles = config.direction === 'row' ?
       {
@@ -100,7 +97,7 @@ class SegmentedControls extends React.Component {
 
     const separatorStyle = [baseOptionContainerStyle, borderStyles];
 
-    const style = selected ? selectedStyle : normalStyle;
+    const textStyle = selected ? selectedTextStyle : normalTextStyle;
 
     const label = this.props.extractText ? this.props.extractText(option) : option;
 
@@ -111,7 +108,7 @@ class SegmentedControls extends React.Component {
       <TouchableWithoutFeedback onPress={onSelect} key={index} disabled={disabled}>
         <View style={[index > 0 ? separatorStyle : baseOptionContainerStyle, this.props.optionContainerStyle]}>
           {typeof this.props.renderOption === 'function' ? this.props.renderOption.call(this, option, selected) : (
-            <Text allowFontScaling={scaleFont} style={style}>{label}</Text>
+            <Text allowFontScaling={scaleFont} style={textStyle}>{label}</Text>
           )}
         </View>
       </TouchableWithoutFeedback>


### PR DESCRIPTION
Thanks @GantMan for the tip on how to fix the styling of the disabled control. Made the text background transparent and also renamed some styling variable names so that they are more readable.
