### PR TITLE
fixing segment bug

### DIFF
--- a/lib/segmented-controls.js
+++ b/lib/segmented-controls.js
@@ -62,7 +62,7 @@ class SegmentedControls extends React.Component {
 
   renderOption(config, option, selected, onSelect, index){
 
-    const disabled = !this.props.enabled || false;
+    const disabled = this.props.enabled ? true : false;
 
     const baseTextStyle = {
       textAlign: config.textAlign


### PR DESCRIPTION
you can't use bang on undefined and then expect it to hit `||`.  Bang will convert undefined to bool.

This fixes #45 
