### PR TITLE
Add documentation for containerStyle prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,11 @@ const DEFAULTS = {
 }
 ```
 
-You can also specify `optionContainerStyle` and `optionStyle` to use any style you want.
+You can also specify `containerStyle`, `optionContainerStyle`, and `optionStyle` to use any style you want:
+
+* `containerStyle` - optional styles to be applied to the outermost `<View>` component.
+* `optionStyle` - optional styles to be applied to the `<Text>` elements of the options themselves.
+* `optionContainerStyle` - optional styles to be applied to the the `<View>` that contain the options.
 
 You can also specify how to extract the labels from the options through the extractText prop.
 


### PR DESCRIPTION
Support (and documentation) for `containerStyle` was added to `SegmentedControls` in 5d15bd0.  However, the documentation for it was removed in #54 (probably by accident).

This PR adds back the documentation for `containerStyle` and adds additional information about what all three style props do.

The documentation for `optionStyle` and `optionContainerStyle` was copied from `RadioButtons` above, so may be redundant, but there’s no other place to more fully document `containerStyle`, because that style doesn’t apply to `RadioButtons`; it only applies to `SegmentedControls`.