### PR TITLE
Allow StyleSheet styles as containerStyle

### DIFF
--- a/lib/segmented-controls.js
+++ b/lib/segmented-controls.js
@@ -43,16 +43,17 @@ class SegmentedControls extends React.Component {
   }
 
   renderContainer(config, options){
-    var containerStyle = {
+    var baseContainerStyle = {
       flexDirection: config.direction,
       backgroundColor: config.backgroundColor,
       borderColor: config.containerBorderTint,
       borderWidth: config.containerBorderWidth,
-      overflow: 'hidden',
-      ...this.props.containerStyle,
+      overflow: 'hidden'
     };
 
-    containerStyle.borderRadius = config.containerBorderRadius;
+    baseContainerStyle.borderRadius = config.containerBorderRadius;
+
+    const containerStyle = [baseContainerStyle, this.props.containerStyle];
 
     return <View style={ containerStyle }>{options}</View>;
   }


### PR DESCRIPTION
`SegmentedControls` allows the passing of a `containerStyle` prop to customize the styling of the outermost `<View>` component.  However, the way it merges `this.props.containerStyle` into the baseline container styles doesn’t work with styles that come from a React Native `StyleSheet`.

Styles from a `StyleSheet` are passed around as an integer that references a StyleSheet object.  When passed to a React Native component, the reference is resolved into a style object.  The original implementation was using object-spread notation to merge the `containerStyle` prop into the baseline styles.  This works fine if `containerStyle` is an object, but doesn’t work when it’s an integer stylesheet reference.

This PR modifies the handling of the `containerStyle` prop to put it into an array with the base container styles.  React Native then resolves all of the styles appropriately.

This new implementation also more closely matches what is done in `renderOption`, so this makes the style handling code more consistent throughout the file.