### PR TITLE
Fix stand-alone prop-types modules warnings

### DIFF
--- a/lib/radio-buttons.js
+++ b/lib/radio-buttons.js
@@ -1,6 +1,7 @@
 'use strict';
 var React = require('react');
 var ReactNative = require('react-native');
+var PropTypes = require('prop-types');
 
 const {
   Text,
@@ -9,11 +10,11 @@ const {
 } = ReactNative;
 
 const propTypes = {
-  options: React.PropTypes.array.isRequired,
-  testOptionEqual: React.PropTypes.func,
-  renderOption: React.PropTypes.func,
-  renderContainer: React.PropTypes.func,
-  onSelection: React.PropTypes.func,
+  options: PropTypes.array.isRequired,
+  testOptionEqual: PropTypes.func,
+  renderOption: PropTypes.func,
+  renderContainer: PropTypes.func,
+  onSelection: PropTypes.func,
 };
 
 class RadioButtons extends React.Component {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "url": "git@github.com:ArnaudRinquin/react-native-radio-buttons.git"
   },
   "peerDependencies": {
+    "prop-types": ">=15.5.0",
     "react-native": ">=0.25.0"
   },
   "keywords": [


### PR DESCRIPTION
Requires a major as it changes `peerDependencies`

Fixes #81

