### PR TITLE
Fix borderRadius display error when there is only 2 options

### DIFF
--- a/lib/segmented-controls.js
+++ b/lib/segmented-controls.js
@@ -120,7 +120,7 @@ class SegmentedControls extends React.Component {
               borderBottomRightRadius: adjustedBorderRadius
             }
         }
-        if (index === this.props.options.length - 2) {
+        if (index === this.props.options.length - 2 &&  && this.props.options.length !== 2) {
           borderRadiusStyle =  config.direction === 'row' ?
             {
               borderRightWidth: config.separatorWidth,

--- a/lib/segmented-controls.js
+++ b/lib/segmented-controls.js
@@ -120,7 +120,7 @@ class SegmentedControls extends React.Component {
               borderBottomRightRadius: adjustedBorderRadius
             }
         }
-        if (index === this.props.options.length - 2 &&  && this.props.options.length !== 2) {
+        if (index === this.props.options.length - 2 && this.props.options.length !== 2) {
           borderRadiusStyle =  config.direction === 'row' ?
             {
               borderRightWidth: config.separatorWidth,


### PR DESCRIPTION
When thers is only 2 options, this brancn condition will break first option's borderRadius props, this new condition will fix this, but made no seprator between two options. Consider in most scene one of the option will always be seleced, this side effect can be accepted.