### PR TITLE
Update README to use HTTPS url over SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm i -S react-native-radio-buttons
 ## Demo app
 
 ```sh
-git clone git@github.com:ArnaudRinquin/react-native-radio-buttons.git
+git clone https://github.com/ArnaudRinquin/react-native-radio-buttons.git
 cd react-native-radio-buttons
 npm run demo
 ```


### PR DESCRIPTION
In the Demo section the repo's url was updated to use HTTPS instead of SSH as recommended by GitHub.
See https://help.github.com/articles/which-remote-url-should-i-use/#cloning-with-https-urls-recommended